### PR TITLE
risc0-zkvm: 0.19.1 -> 0.20.1

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,7 +8,7 @@ bincode = "1.3.3"
 console_error_panic_hook = "0.1.7"
 env_logger = "0.11.2"
 log = "0.4.21"
-risc0-zkvm = { version = "0.19.1", default-features = false }
+risc0-zkvm = { version = "0.20.1", default-features = false }
 serde = "1.0.197"
 serde_json = "1.0.114"
 serde-wasm-bindgen = "0.6.5"


### PR DESCRIPTION
I was getting this error from the verifier for a proof generated with v0.20.1

![2024-03-07-111558_1033x209_scrot](https://github.com/eqtylab/risc-zero-verifier/assets/21013281/63537976-12a5-434c-a0a5-e66941379856)
