### PR TITLE
Show risc0 version and remove unneccessary async everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "risc-zero-verifier"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "console_error_panic_hook",
@@ -661,7 +661,6 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -969,18 +968,6 @@ dependencies = [
  "quote",
  "syn 2.0.52",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqty/risc-zero-verifier-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src --out-dir dist",

--- a/react/src/Verifier.js
+++ b/react/src/Verifier.js
@@ -56,7 +56,7 @@ function Verifier({
     }
   }, [receiptJson]);
 
-  async function verifyRiscZeroReceipt(guestCodeId, receiptJson) {
+function verifyRiscZeroReceipt(guestCodeId, receiptJson) {
     if (!guestCodeId) {
       return text.errors.guestCodeIdMissing;
     }
@@ -66,7 +66,7 @@ function Verifier({
     }
     
     try {
-      let result = await verifier.verify_receipt_json(guestCodeId, receiptJson);
+      let result = verifier.verify_receipt_json(guestCodeId, receiptJson);
       if (result.verified === true) {
         return text.verificationResults.verified;
       } else {
@@ -82,7 +82,7 @@ function Verifier({
 
     if (file) {
       const reader = new FileReader();
-      reader.onload = async (e) => {
+      reader.onload = (e) => {
         const text = e.target.result;
 
         // Try parsing as JSON
@@ -94,10 +94,10 @@ function Verifier({
         } catch (error) {
           // Try to convert from binary, expecting bincode format, if JSON parsing fails
           const fallbackReader = new FileReader();
-          fallbackReader.onload = async (e) => {
+          fallbackReader.onload = (e) => {
             const arrayBuffer = e.target.result;
             const byteArray = new Uint8Array(arrayBuffer);
-            receiptJson = await verifier.binary_to_json(byteArray);
+            receiptJson = verifier.binary_to_json(byteArray);
             setReceiptBinary(byteArray);
             setReceiptJson(receiptJson);
             console.debug("Receipt: ", byteArray);
@@ -122,7 +122,10 @@ function Verifier({
   return (
     <div className={cssClass("main")}>
       <div className={cssClass("instructions-container")}>
-        <p>{text.instructions}</p>
+        <p className={cssClass("instructions-text")}>{text.instructions}</p>
+        {verifier && (
+          <p className={cssClass("instructions-version")}>Receipts must be generated with <code>risc0-zkvm</code> rust crate version <code>{verifier.get_risc0_version()}</code>.</p>
+        )}
       </div>
       <div className={cssClass("guest-code-id-container")}>
         <label htmlFor={cssId("guest-code-input")}>{text.fieldLabels.guestCodeId}</label>
@@ -143,7 +146,7 @@ function Verifier({
         </div>
       </div>
       <div className={cssClass("verify-button-container")}>
-        <button id={cssId("verify-button")} onClick={async () => setVerificationResult(await verifyRiscZeroReceipt(guestCodeId, receiptJson))}>{text.verifyButtonLabel}</button>
+        <button id={cssId("verify-button")} onClick={() => setVerificationResult(verifyRiscZeroReceipt(guestCodeId, receiptJson))}>{text.verifyButtonLabel}</button>
       </div>
 
       {verificationResult && (

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc-zero-verifier"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]
@@ -13,7 +13,6 @@ serde = "1.0.197"
 serde_json = "1.0.114"
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4.41"
 hex = "0.4.3"
 
 [dependencies.web-sys]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,7 +11,14 @@ struct ReceiptVerificationResult {
 }
 
 #[wasm_bindgen]
-pub async fn binary_to_json(receipt: Vec<u8>) -> Result<JsValue, JsValue> {
+pub fn get_risc0_version() -> Result<JsValue, JsValue> {
+    let r0_version = risc0_zkvm::get_version().map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    Ok(JsValue::from_str(&r0_version.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn binary_to_json(receipt: Vec<u8>) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
     console::log_1(&JsValue::from_str(
@@ -36,7 +43,7 @@ pub async fn binary_to_json(receipt: Vec<u8>) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen]
-pub async fn verify_receipt_json(
+pub fn verify_receipt_json(
     guest_code_id_hex_string: &str,
     receipt_json: &str,
 ) -> Result<JsValue, JsValue> {
@@ -54,11 +61,11 @@ pub async fn verify_receipt_json(
         ))
     })?;
 
-    verify_receipt(guest_code_id_hex_string, receipt).await
+    verify_receipt(guest_code_id_hex_string, receipt)
 }
 
 #[wasm_bindgen]
-pub async fn verify_receipt_binary(
+pub fn verify_receipt_binary(
     guest_code_id_hex_string: &str,
     receipt_binary: Vec<u8>,
 ) -> Result<JsValue, JsValue> {
@@ -76,10 +83,10 @@ pub async fn verify_receipt_binary(
         ))
     })?;
 
-    verify_receipt(guest_code_id_hex_string, receipt).await
+    verify_receipt(guest_code_id_hex_string, receipt)
 }
 
-async fn verify_receipt(
+fn verify_receipt(
     guest_code_id_hex_string: &str,
     receipt: Receipt,
 ) -> Result<JsValue, JsValue> {


### PR DESCRIPTION
Receipt verification can fail if they're generated with a different version of the risc0 libraries, so display the version that this verifier expects.

Also removed async everywhere, it wasn't necessary.